### PR TITLE
feat: (ODE-106) content collection schemas and homepage sections

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -31,6 +31,7 @@ const projects = defineCollection({
       .optional(),
     stack: z.array(z.string()).default([]),
     featured: z.boolean().default(false),
+    draft: z.boolean().default(false),
   }),
 });
 
@@ -41,7 +42,7 @@ const learning = defineCollection({
     description: z.string(),
     startedAt: z.coerce.date(),
     updatedAt: z.coerce.date().optional(),
-    status: z.enum(["in_progress", "completed", "paused"]),
+    status: z.enum(["in-progress", "completed", "paused"]),
     tags: z.array(z.string()).default([]),
   }),
 });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,22 +1,98 @@
 ---
+import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { formatDate } from "../utils/formatDate";
+
+const allProjects = await getCollection('projects');
+const featureProjects = allProjects
+	.filter(project => project.data.featured && !project.data.draft)
+	.slice(0,2);
+
+const allPosts = await getCollection('blog', ({ data: blog }) => !blog.draft);
+const recentPosts = allPosts.sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf()).slice(0,3);
+
 ---
 <BaseLayout title="Home" description="Fullstack software engineer. Building apps with React Native and Expo.">
-	<div class="intro">
-		<h1>Loïc Ishimwe (odeloic)</h1>
-		<p class="tagline">
-			Fullstack Software Engineer. <br>
-			Building apps with React Native and Expo.
-			<span class="accent">Learning and building in public.</span>
-		</p>
+	<div class="home">
+		<section class="hero">
+			<h1>Loïc Ishimwe (odeloic)</h1>
+			<p class="tagline">
+				Fullstack Software Engineer. <br>
+				Building apps with React Native and Expo.
+				<span class="accent">Learning and building in public.</span>
+			</p>
+		</section>
+
+		{featureProjects.length > 0 && (
+			<section class="section">
+				<h2 class="section-label">Featured Projects</h2>
+				<div class="card-grid">
+					{featureProjects.map((project) => (
+						<article class="card">
+							<div class="card-header">
+								<h3>{project.data.title}</h3>
+								<span class={`status-badge status-badge--${project.data.status}`}>
+									{project.data.status}
+								</span>
+							</div>
+							<p class="card-description">{project.data.description}</p>
+							{project.data.stack.length > 0 && (
+								<div class="tags">
+									{project.data.stack.map((tech) => (
+										<span class="tag">{tech}</span>
+									))}
+								</div>
+							)}
+							{project.data.links && (
+								<div class="card-links">
+									{project.data.links.github && (
+										<a href={project.data.links.github}>GitHub</a>
+									)}
+									{project.data.links.live && (
+										<a href={project.data.links.live}>Live</a>
+									)}
+									{project.data.links.demo && (
+										<a href={project.data.links.demo}>Demo</a>
+									)}
+								</div>
+							)}
+						</article>
+					))}
+				</div>
+				<a href="/projects" class="btn btn--secondary">View all projects</a>
+			</section>
+		)}
+
+		{recentPosts.length > 0 && (
+			<section class="section">
+				<h2 class="section-label">Recent Posts</h2>
+				<div class="card-list">
+					{recentPosts.map((post) => (
+						<article class="card">
+							<div class="card-header">
+								<h3><a href={`/blog/${post.slug}`}>{post.data.title}</a></h3>
+								<time class="text-muted" datetime={post.data.publishedAt.toISOString()}>
+									{formatDate(post.data.publishedAt)}
+								</time>
+							</div>
+							<p class="card-description">{post.data.description}</p>
+							{post.data.tags.length > 0 && (
+								<div class="tags">
+									{post.data.tags.map((tag) => (
+										<span class="tag">{tag}</span>
+									))}
+								</div>
+							)}
+						</article>
+					))}
+				</div>
+				<a href="/blog" class="btn btn--secondary">View all posts</a>
+			</section>
+		)}
 	</div>
 </BaseLayout>
 
 <style>
-	.intro	{
-		margin-bottom: 5rem;
-	}
-
 	h1 {
 		margin-bottom: var(--space-md);
 	}
@@ -29,5 +105,52 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 	.accent {
 		color: var(--color-accent);
+	}
+
+	.section {
+		margin-top: var(--space-3xl);
+	}
+
+	.section-label {
+		margin-bottom: var(--space-lg);
+	}
+
+	.card-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+		gap: var(--space-lg);
+		margin-bottom: var(--space-xl);
+	}
+
+	.card-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-lg);
+		margin-bottom: var(--space-xl);
+	}
+
+	.card-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: var(--space-md);
+		margin-bottom: var(--space-sm);
+	}
+
+	.card-description {
+		color: var(--color-text-muted);
+		margin-bottom: var(--space-md);
+	}
+
+	.tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-xs);
+	}
+
+	.card-links {
+		display: flex;
+		gap: var(--space-md);
+		margin-top: var(--space-md);
 	}
 </style>

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,7 @@
+export const formatDate = (date: Date) => {
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+};


### PR DESCRIPTION
## Summary
- Fix `projects.draft` schema to `default(false)` so draft is optional in frontmatter (consistent with blog collection)
- Fix learning status enum from `in_progress` to `in-progress` (hyphenated, per spec)
- Complete homepage with **Featured Projects** and **Recent Posts** sections using design system classes (`.card`, `.section-label`, `.tag`, `.status-badge`, `.btn--secondary`)
- Add `formatDate` utility for post date formatting

## Test plan
- [x] `npm run build` — clean production build (no schema errors)
- [x] `npm run dev` — homepage loads without errors
- [ ] Verify featured projects section renders correctly once project content is added
- [ ] Verify recent posts section renders correctly once blog content is added