### PR TITLE
feat: add Tempor app privacy policy and support pages

### DIFF
--- a/src/pages/apps/tempor/privacy.astro
+++ b/src/pages/apps/tempor/privacy.astro
@@ -1,0 +1,43 @@
+---
+import PageLayout from '../../../layouts/PageLayout.astro';
+---
+
+<PageLayout
+  title="TemporHQ — Privacy Policy"
+  description="Privacy policy for TemporHQ, a time tracking application that prioritizes user privacy through local-only data storage."
+  updatedAt="2026-02-10"
+>
+  <h2>Overview</h2>
+  <p>TemporHQ ("the App") is a time tracking application. Your privacy is important to us. This policy explains how the App handles your data.</p>
+
+  <h2>Data Storage</h2>
+  <p>All data you create in the App — including projects, time entries, and settings — is stored <strong>locally on your device</strong>. No data is transmitted to external servers, cloud services, or third parties.</p>
+
+  <h2>Data Collection</h2>
+  <p>The App does <strong>not</strong> collect, store, or share any personal information. Specifically:</p>
+  <ul>
+    <li>No account creation or login is required</li>
+    <li>No analytics or usage tracking</li>
+    <li>No advertising or ad-related data collection</li>
+    <li>No crash reporting sent to external services</li>
+    <li>No cookies or web tracking technologies</li>
+  </ul>
+
+  <h2>Notifications</h2>
+  <p>The App uses local notifications to remind you about running timers. These notifications are processed entirely on your device and do not involve any external servers. You can disable notifications at any time through the App's settings or your device's system settings.</p>
+
+  <h2>Third-Party Services</h2>
+  <p>The App does not integrate with any third-party services that collect or process user data.</p>
+
+  <h2>Data Deletion</h2>
+  <p>Since all data is stored locally on your device, you can delete all App data at any time by uninstalling the App.</p>
+
+  <h2>Children's Privacy</h2>
+  <p>The App does not knowingly collect any information from children under the age of 13.</p>
+
+  <h2>Changes to This Policy</h2>
+  <p>We may update this privacy policy from time to time. Any changes will be reflected by updating the "Last updated" date above.</p>
+
+  <h2>Contact</h2>
+  <p>If you have questions about this privacy policy, please contact us at: <a href="mailto:odeloic.ws@gmail.com">odeloic.ws@gmail.com</a></p>
+</PageLayout>

--- a/src/pages/apps/tempor/support.astro
+++ b/src/pages/apps/tempor/support.astro
@@ -1,0 +1,13 @@
+---
+import PageLayout from '../../../layouts/PageLayout.astro';
+---
+
+<PageLayout
+  title="TemporHQ — Support"
+  description="Get help with TemporHQ, a time tracking application."
+>
+  <p>Need help with TemporHQ? We're here to assist you with any questions or issues you may have.</p>
+
+  <h2>Contact</h2>
+  <p>Reach out to us at <a href="mailto:odeloic.ws@gmail.com">odeloic.ws@gmail.com</a> and we'll get back to you as soon as possible.</p>
+</PageLayout>


### PR DESCRIPTION
## Summary
- Add `/apps/tempor/privacy` — full privacy policy page for App Store compliance
- Add `/apps/tempor/support` — support contact page with email link
- Both pages reuse `PageLayout` for consistent styling (header, footer, theme support)

## Test plan
- [ ] `npm run build` passes with both new pages generated
- [ ] `/apps/tempor/privacy` renders all policy sections
- [ ] `/apps/tempor/support` renders with working mailto link
- [ ] Both pages work in light and dark themes