### PR TITLE
feat: add content pages, card components, and design token fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/pages/` contains route files (`index.astro`, `about.astro`), each mapping to a URL.
+- `src/layouts/` holds shared page shells (`BaseLayout.astro`, `PageLayout.astro`).
+- `src/components/` is for reusable UI pieces (e.g., `Header.astro`, `ThemeToggle.astro`).
+- `src/styles/` contains global CSS (`global.css`).
+- `src/utils/` holds small TypeScript helpers (e.g., `formatDate.ts`).
+- `src/content/` stores content collections and their config.
+- `public/` is for static assets served as-is.
+
+## Build, Test, and Development Commands
+Run all commands from the repo root:
+- `npm install`: install dependencies.
+- `npm run dev`: start the Astro dev server at `http://localhost:4321`.
+- `npm run build`: generate the production site in `dist/`.
+- `npm run preview`: serve the production build locally.
+- `npm run astro check`: run Astro checks (types/content). Use `npm run astro -- --help` for more CLI options.
+
+## Coding Style & Naming Conventions
+- Use 2-space indentation in Astro/CSS/TS to match existing files.
+- Component and layout filenames use `PascalCase` (e.g., `BaseHeader.astro`).
+- Utility functions use `camelCase` in `src/utils/` (e.g., `formatDate.ts`).
+- Prefer colocating styles in `src/styles/` or component-level `<style>` blocks when appropriate.
+
+## Testing Guidelines
+- No automated test framework is configured. At minimum, run `npm run build` before opening a PR.
+- If you add tests, document the framework and add a matching npm script.
+
+## Commit & Pull Request Guidelines
+- Commits follow a Conventional Commit style: `feat:`, `chore:`, `ci:`, etc. Optional scopes or ticket IDs are used (e.g., `feat: (ODE-104) about page`).
+- PRs should include a concise summary, list of changes, and linked issues when applicable.
+- For UI changes, include before/after screenshots or a short screen recording.
+
+## Configuration Tips
+- `astro.config.mjs` and `tsconfig.json` define build and TypeScript behavior. Update them alongside any structural changes (new aliases, content collections, or integrations).

--- a/README.md
+++ b/README.md
@@ -1,43 +1,79 @@
-# Astro Starter Kit: Minimal
+# odeloic.com
 
-```sh
-npm create astro@latest -- --template minimal
+Personal website built with [Astro](https://astro.build). Blog, projects, learning logs, and tags.
+
+## Commands
+
+| Command | Action |
+| :--- | :--- |
+| `npm install` | Install dependencies |
+| `npm run dev` | Start dev server at `localhost:4321` |
+| `npm run build` | Build production site to `./dist/` |
+| `npm run preview` | Preview build locally |
+
+## Adding Content
+
+All content lives in `src/content/` as markdown files. Each content type has its own folder and schema.
+
+### Blog Posts
+
+Add a `.md` file to `src/content/blog/`.
+
+**Required frontmatter:** `title`, `description`, `publishedAt`, `tags`
+
+**Optional:** `updatedAt`, `draft` (default: false), `featured` (default: false)
+
+- Posts with `draft: true` are excluded from the site
+- Posts with `featured: true` appear on the homepage
+- Tags link to `/tags/{tag}` pages automatically
+
+See the full example: [docs/example-blog-post.md](docs/example-blog-post.md)
+
+### Projects
+
+Add a `.md` file to `src/content/projects/`.
+
+**Required frontmatter:** `title`, `description`, `status`, `startedAt`, `version`
+
+**Optional:** `tags`, `stack`, `links` (github/live/demo URLs), `featured` (default: false), `draft` (default: false)
+
+- `status` must be one of: `active`, `maintained`, `archived`, `idea`
+- Featured projects appear on the homepage
+- The `stack` array renders as tech tags on the project card
+- External links (GitHub, Live, Demo) render as buttons on the detail page
+
+See the full example: [docs/example-project.md](docs/example-project.md)
+
+### Learning Logs
+
+Add a `.md` file to `src/content/learning/`.
+
+**Required frontmatter:** `title`, `description`, `startedAt`, `status`
+
+**Optional:** `updatedAt`, `tags`
+
+- `status` must be one of: `in-progress`, `completed`, `paused`
+- Use `## Date` headings (e.g. `## January 10, 2025`) as dated entries — they're styled as a timeline on the detail page
+- Update `updatedAt` each time you add new entries
+
+See the full example: [docs/example-learning-log.md](docs/example-learning-log.md)
+
+### Tags
+
+Tags are generated automatically. Any tag used in blog posts, projects, or learning logs appears on the `/tags` page with a count, and gets its own `/tags/{tag}` page grouping all content with that tag.
+
+## Project Structure
+
 ```
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
+src/
+├── components/     # Reusable UI components
+├── content/
+│   ├── blog/       # Blog posts (.md)
+│   ├── projects/   # Projects (.md)
+│   ├── learning/   # Learning logs (.md)
+│   └── config.ts   # Collection schemas
+├── layouts/        # Page layouts
+├── pages/          # File-based routing
+├── styles/         # Global CSS and design tokens
+└── utils/          # Shared utilities
 ```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/docs/example-blog-post.md
+++ b/docs/example-blog-post.md
@@ -1,0 +1,28 @@
+---
+title: "Your Post Title"
+description: "A short summary of what this post is about."
+publishedAt: 2025-01-15
+updatedAt: 2025-02-01 # optional
+tags: ["tag-one", "tag-two"]
+draft: false
+featured: false # optional, shows on homepage if true
+---
+
+Your markdown content goes here.
+
+## A Section
+
+Regular paragraphs, **bold**, *italic*, [links](https://example.com), and everything else markdown supports.
+
+```typescript
+// Code blocks get syntax highlighting automatically
+const greeting = "hello world";
+```
+
+> Blockquotes work too.
+
+- Bullet lists
+- Work as expected
+
+1. So do
+2. Numbered lists

--- a/docs/example-learning-log.md
+++ b/docs/example-learning-log.md
@@ -1,0 +1,34 @@
+---
+title: "Topic You're Learning"
+description: "What this learning log covers and why."
+startedAt: 2025-01-10
+updatedAt: 2025-02-01 # optional, update this as you add entries
+status: "in-progress" # in-progress | completed | paused
+tags: ["tag-one", "tag-two"]
+---
+
+## January 10, 2025
+
+### First Topic
+
+What you learned, what you tried, what worked or didn't.
+
+- Key takeaway one
+- Key takeaway two
+
+## January 18, 2025
+
+### Second Topic
+
+Use `##` headings as dated entries — they get styled as a timeline on the detail page.
+
+```typescript
+// Code snippets for things you're learning
+const example = "include code when relevant";
+```
+
+## January 28, 2025
+
+### Third Topic
+
+Keep adding entries as you learn. Update the `updatedAt` date in frontmatter each time.

--- a/docs/example-project.md
+++ b/docs/example-project.md
@@ -1,0 +1,33 @@
+---
+title: "Project Name"
+description: "A short description of what this project does."
+status: "active" # active | maintained | archived | idea
+startedAt: 2025-01-01
+version: "0.1.0"
+tags: ["tag-one", "tag-two"]
+stack: ["React Native", "TypeScript", "SQLite"]
+links:
+  github: "https://github.com/you/project" # optional
+  live: "https://project.example.com" # optional
+  demo: "https://demo.example.com" # optional
+featured: true # optional, shows on homepage if true
+draft: false
+---
+
+## About
+
+Describe the project — what it does, why you built it, what problem it solves.
+
+## Current Features
+
+- Feature one
+- Feature two
+- Feature three
+
+## What's Next
+
+What you're planning to work on next.
+
+## Technical Notes
+
+Any interesting implementation details, architecture decisions, or lessons learned.

--- a/src/components/Changelog.astro
+++ b/src/components/Changelog.astro
@@ -1,0 +1,123 @@
+---
+interface ChangelogEntry {
+  version: string;
+  date: string;
+  changes: string[];
+  lessons?: string[];
+}
+
+interface Props {
+  entries: ChangelogEntry[];
+}
+
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="changelog">
+    <h2>Changelog</h2>
+    <div class="timeline">
+      {entries.map((entry) => (
+        <div class="timeline-entry">
+          <div class="timeline-marker"></div>
+          <div class="timeline-content">
+            <div class="timeline-header">
+              <span class="version">{entry.version}</span>
+              <time class="text-muted">{entry.date}</time>
+            </div>
+            <ul class="changes">
+              {entry.changes.map((change) => (
+                <li>{change}</li>
+              ))}
+            </ul>
+            {entry.lessons && entry.lessons.length > 0 && (
+              <div class="lessons">
+                <strong>Lessons learned:</strong>
+                <ul>
+                  {entry.lessons.map((lesson) => (
+                    <li>{lesson}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  </section>
+)}
+
+<style>
+  .changelog h2 {
+    margin-bottom: var(--space-lg);
+  }
+
+  .timeline {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+    padding-left: var(--space-lg);
+    border-left: 2px solid var(--color-border);
+  }
+
+  .timeline-entry {
+    position: relative;
+  }
+
+  .timeline-marker {
+    position: absolute;
+    left: calc(-1 * var(--space-lg) - 5px);
+    top: 6px;
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-full);
+    background: var(--color-accent);
+  }
+
+  .timeline-header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .version {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+
+  .changes {
+    padding-left: var(--space-lg);
+    margin-bottom: var(--space-sm);
+  }
+
+  .changes li {
+    margin-bottom: var(--space-xs);
+    color: var(--color-text-muted);
+  }
+
+  .lessons {
+    margin-top: var(--space-sm);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--color-accent-muted);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-sm);
+  }
+
+  .lessons strong {
+    display: block;
+    margin-bottom: var(--space-xs);
+    color: var(--color-text);
+  }
+
+  .lessons ul {
+    padding-left: var(--space-lg);
+  }
+
+  .lessons li {
+    margin-bottom: var(--space-xs);
+    color: var(--color-text-muted);
+  }
+</style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,0 +1,79 @@
+---
+import { formatDate } from '../utils/formatDate';
+
+interface Props {
+  title: string;
+  description: string;
+  publishedAt: Date;
+  tags: string[];
+  slug: string;
+}
+
+const { title, description, publishedAt, tags, slug } = Astro.props;
+---
+
+<article class="post-card">
+  <div class="card-header">
+    <h3><a href={`/blog/${slug}`}>{title}</a></h3>
+    <time class="text-muted" datetime={publishedAt.toISOString()}>
+      {formatDate(publishedAt)}
+    </time>
+  </div>
+  <p class="card-description">{description}</p>
+  {tags.length > 0 && (
+    <div class="tags">
+      {tags.map((tag) => (
+        <a href={`/tags/${tag}`} class="tag">{tag}</a>
+      ))}
+    </div>
+  )}
+</article>
+
+<style>
+  .post-card {
+    padding: var(--space-lg);
+    background: var(--color-bg-secondary);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border);
+    transition: border-color var(--transition-fast);
+  }
+
+  .post-card:hover {
+    border-color: var(--color-accent);
+  }
+
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .card-header h3 a {
+    color: var(--color-text);
+    text-decoration: none;
+  }
+
+  .card-header h3 a:hover {
+    color: var(--color-accent);
+  }
+
+  .card-description {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  @media (max-width: 640px) {
+    .card-header {
+      flex-direction: column;
+      gap: var(--space-xs);
+    }
+  }
+</style>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,0 +1,109 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  status: string;
+  version: string;
+  stack: string[];
+  slug: string;
+  links?: {
+    github?: string;
+    live?: string;
+    demo?: string;
+  };
+}
+
+const { title, description, status, version, stack, slug, links } = Astro.props;
+---
+
+<article class="project-card">
+  <div class="card-header">
+    <h3><a href={`/projects/${slug}`}>{title}</a></h3>
+    <span class={`status-badge status-badge--${status}`}>{status}</span>
+  </div>
+  <p class="card-description">{description}</p>
+  <div class="card-meta">
+    <span class="version">v{version}</span>
+    {stack.length > 0 && (
+      <div class="tags">
+        {stack.map((tech) => (
+          <span class="tag">{tech}</span>
+        ))}
+      </div>
+    )}
+  </div>
+  {links && (
+    <div class="card-links">
+      {links.github && (
+        <a href={links.github} target="_blank" rel="noopener noreferrer">GitHub</a>
+      )}
+      {links.live && (
+        <a href={links.live} target="_blank" rel="noopener noreferrer">Live</a>
+      )}
+      {links.demo && (
+        <a href={links.demo} target="_blank" rel="noopener noreferrer">Demo</a>
+      )}
+    </div>
+  )}
+</article>
+
+<style>
+  .project-card {
+    padding: var(--space-lg);
+    background: var(--color-bg-secondary);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border);
+    transition: border-color var(--transition-fast);
+  }
+
+  .project-card:hover {
+    border-color: var(--color-accent);
+  }
+
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .card-header h3 a {
+    color: var(--color-text);
+    text-decoration: none;
+  }
+
+  .card-header h3 a:hover {
+    color: var(--color-accent);
+  }
+
+  .card-description {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+
+  .card-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .version {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  .card-links {
+    display: flex;
+    gap: var(--space-md);
+    margin-top: var(--space-md);
+  }
+</style>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,0 +1,151 @@
+---
+import BaseLayout from './BaseLayout.astro';
+import { formatDate } from '../utils/formatDate';
+
+interface Props {
+  title: string;
+  description: string;
+  publishedAt: Date;
+  updatedAt?: Date;
+  tags: string[];
+}
+
+const { title, description, publishedAt, updatedAt, tags } = Astro.props;
+---
+
+<BaseLayout title={title} description={description}>
+  <article class="post">
+    <header class="post-header">
+      <a href="/blog" class="back-link">&larr; Back to blog</a>
+      <h1>{title}</h1>
+      <div class="post-meta">
+        <time datetime={publishedAt.toISOString()}>
+          {formatDate(publishedAt)}
+        </time>
+        {updatedAt && (
+          <span class="updated">
+            (Updated {formatDate(updatedAt)})
+          </span>
+        )}
+      </div>
+      {tags.length > 0 && (
+        <div class="post-tags">
+          {tags.map((tag) => (
+            <a href={`/tags/${tag}`} class="tag">{tag}</a>
+          ))}
+        </div>
+      )}
+    </header>
+    <div class="post-content">
+      <slot />
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .post {
+    max-width: 600px;
+  }
+
+  .back-link {
+    display: inline-block;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-lg);
+  }
+
+  .back-link:hover {
+    color: var(--color-accent);
+  }
+
+  .post-header {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .post-header h1 {
+    margin-bottom: var(--space-sm);
+  }
+
+  .post-meta {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+
+  .updated {
+    color: var(--color-text-muted);
+  }
+
+  .post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  .post-content {
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-relaxed);
+    color: var(--color-text-muted);
+  }
+
+  .post-content :global(p) {
+    margin-bottom: var(--space-lg);
+  }
+
+  .post-content :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .post-content :global(strong),
+  .post-content :global(a) {
+    color: var(--color-text);
+  }
+
+  .post-content :global(a) {
+    color: var(--color-accent);
+  }
+
+  .post-content :global(h2) {
+    font-size: var(--font-size-xl);
+    color: var(--color-text);
+    margin-top: var(--space-2xl);
+    margin-bottom: var(--space-md);
+  }
+
+  .post-content :global(h3) {
+    font-size: var(--font-size-lg);
+    color: var(--color-text);
+    margin-top: var(--space-xl);
+    margin-bottom: var(--space-sm);
+  }
+
+  .post-content :global(ul),
+  .post-content :global(ol) {
+    margin-bottom: var(--space-lg);
+    padding-left: var(--space-lg);
+  }
+
+  .post-content :global(li) {
+    margin-bottom: var(--space-sm);
+  }
+
+  .post-content :global(blockquote) {
+    border-left: 3px solid var(--color-accent);
+    padding-left: var(--space-md);
+    margin: var(--space-lg) 0;
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .post-content :global(pre) {
+    margin-bottom: var(--space-lg);
+    border-radius: var(--radius-lg);
+    overflow-x: auto;
+  }
+
+  .post-content :global(img) {
+    max-width: 100%;
+    height: auto;
+    border-radius: var(--radius-md);
+  }
+</style>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,0 +1,174 @@
+---
+import BaseLayout from './BaseLayout.astro';
+
+interface Props {
+  title: string;
+  description: string;
+  status: string;
+  version: string;
+  tags: string[];
+  stack: string[];
+  links?: {
+    github?: string;
+    live?: string;
+    demo?: string;
+  };
+}
+
+const { title, description, status, version, tags, stack, links } = Astro.props;
+---
+
+<BaseLayout title={title} description={description}>
+  <article class="project">
+    <header class="project-header">
+      <a href="/projects" class="back-link">&larr; Back to projects</a>
+      <div class="title-row">
+        <h1>{title}</h1>
+        <span class={`status-badge status-badge--${status}`}>{status}</span>
+      </div>
+      <p class="project-description">{description}</p>
+      <div class="project-meta">
+        <span class="version">v{version}</span>
+        {tags.length > 0 && (
+          <div class="project-tags">
+            {tags.map((tag) => (
+              <a href={`/tags/${tag}`} class="tag">{tag}</a>
+            ))}
+          </div>
+        )}
+      </div>
+      {stack.length > 0 && (
+        <div class="stack">
+          <span class="stack-label section-label">Stack</span>
+          <div class="stack-tags">
+            {stack.map((tech) => (
+              <span class="tag">{tech}</span>
+            ))}
+          </div>
+        </div>
+      )}
+      {links && (
+        <div class="project-links">
+          {links.github && (
+            <a href={links.github} class="btn btn--secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+          )}
+          {links.live && (
+            <a href={links.live} class="btn btn--primary" target="_blank" rel="noopener noreferrer">Live</a>
+          )}
+          {links.demo && (
+            <a href={links.demo} class="btn btn--secondary" target="_blank" rel="noopener noreferrer">Demo</a>
+          )}
+        </div>
+      )}
+    </header>
+    <div class="project-content">
+      <slot />
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .project {
+    max-width: 600px;
+  }
+
+  .back-link {
+    display: inline-block;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-lg);
+  }
+
+  .back-link:hover {
+    color: var(--color-accent);
+  }
+
+  .project-header {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .title-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .project-description {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+
+  .project-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
+  }
+
+  .version {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+  }
+
+  .project-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  .stack {
+    margin-bottom: var(--space-md);
+  }
+
+  .stack-label {
+    display: block;
+    margin-bottom: var(--space-sm);
+  }
+
+  .stack-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  .project-links {
+    display: flex;
+    gap: var(--space-sm);
+  }
+
+  .project-content {
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-relaxed);
+    color: var(--color-text-muted);
+  }
+
+  .project-content :global(p) {
+    margin-bottom: var(--space-lg);
+  }
+
+  .project-content :global(h2) {
+    font-size: var(--font-size-xl);
+    color: var(--color-text);
+    margin-top: var(--space-2xl);
+    margin-bottom: var(--space-md);
+  }
+
+  .project-content :global(ul),
+  .project-content :global(ol) {
+    margin-bottom: var(--space-lg);
+    padding-left: var(--space-lg);
+  }
+
+  .project-content :global(li) {
+    margin-bottom: var(--space-sm);
+  }
+
+  @media (max-width: 640px) {
+    .title-row {
+      flex-direction: column;
+      gap: var(--space-sm);
+    }
+  }
+</style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,25 @@
+---
+import { getCollection } from 'astro:content';
+import PostLayout from '../../layouts/PostLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await post.render();
+---
+
+<PostLayout
+  title={post.data.title}
+  description={post.data.description}
+  publishedAt={post.data.publishedAt}
+  updatedAt={post.data.updatedAt}
+  tags={post.data.tags}
+>
+  <Content />
+</PostLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,112 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PostCard from '../../components/PostCard.astro';
+
+const allPosts = await getCollection('blog', ({ data }) => !data.draft);
+const posts = allPosts.sort(
+  (a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf()
+);
+
+const allTags = [...new Set(posts.flatMap((post) => post.data.tags))].sort();
+
+const currentTag = Astro.url.searchParams.get('tag');
+const filteredPosts = currentTag
+  ? posts.filter((post) => post.data.tags.includes(currentTag))
+  : posts;
+---
+
+<BaseLayout title="Blog" description="Thoughts on software engineering, learning in public, and building products.">
+  <div class="blog-index">
+    <header class="page-header">
+      <h1>Blog</h1>
+      <p class="text-muted">Thoughts on software engineering, learning in public, and building products.</p>
+    </header>
+
+    {allTags.length > 0 && (
+      <nav class="tag-filters" aria-label="Filter by tag">
+        <a
+          href="/blog"
+          class:list={['tag-filter', { active: !currentTag }]}
+        >
+          All
+        </a>
+        {allTags.map((tag) => (
+          <a
+            href={`/blog?tag=${tag}`}
+            class:list={['tag-filter', { active: currentTag === tag }]}
+          >
+            {tag}
+          </a>
+        ))}
+      </nav>
+    )}
+
+    {filteredPosts.length > 0 ? (
+      <div class="post-list">
+        {filteredPosts.map((post) => (
+          <PostCard
+            title={post.data.title}
+            description={post.data.description}
+            publishedAt={post.data.publishedAt}
+            tags={post.data.tags}
+            slug={post.slug}
+          />
+        ))}
+      </div>
+    ) : (
+      <p class="empty-state text-muted">No posts yet. Check back soon!</p>
+    )}
+  </div>
+</BaseLayout>
+
+<style>
+  .page-header {
+    margin-bottom: var(--space-xl);
+  }
+
+  .page-header h1 {
+    margin-bottom: var(--space-sm);
+  }
+
+  .tag-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-xl);
+  }
+
+  .tag-filter {
+    font-size: var(--font-size-sm);
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-sm);
+    background: var(--color-bg-secondary);
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    text-decoration: none;
+    transition: all var(--transition-fast);
+  }
+
+  .tag-filter:hover {
+    border-color: var(--color-accent);
+    color: var(--color-text);
+    text-decoration: none;
+  }
+
+  .tag-filter.active {
+    background: var(--color-accent);
+    color: var(--color-bg);
+    border-color: var(--color-accent);
+  }
+
+  .post-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .empty-state {
+    padding: var(--space-2xl) 0;
+    text-align: center;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,20 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { formatDate } from "../utils/formatDate";
+import PostCard from "../components/PostCard.astro";
+import ProjectCard from "../components/ProjectCard.astro";
 
 const allProjects = await getCollection('projects');
-const featureProjects = allProjects
+const featuredProjects = allProjects
 	.filter(project => project.data.featured && !project.data.draft)
-	.slice(0,2);
+	.slice(0, 2);
 
 const allPosts = await getCollection('blog', ({ data: blog }) => !blog.draft);
-const recentPosts = allPosts.sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf()).slice(0,3);
-
+const recentPosts = allPosts
+	.sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf())
+	.slice(0, 3);
 ---
+
 <BaseLayout title="Home" description="Fullstack software engineer. Building apps with React Native and Expo.">
 	<div class="home">
 		<section class="hero">
@@ -23,70 +26,45 @@ const recentPosts = allPosts.sort((a, b) => b.data.publishedAt.valueOf() - a.dat
 			</p>
 		</section>
 
-		{featureProjects.length > 0 && (
+		{featuredProjects.length > 0 && (
 			<section class="section">
-				<h2 class="section-label">Featured Projects</h2>
+				<div class="section-header">
+					<h2 class="section-label">Featured Projects</h2>
+					<a href="/projects" class="section-link">View all &rarr;</a>
+				</div>
 				<div class="card-grid">
-					{featureProjects.map((project) => (
-						<article class="card">
-							<div class="card-header">
-								<h3>{project.data.title}</h3>
-								<span class={`status-badge status-badge--${project.data.status}`}>
-									{project.data.status}
-								</span>
-							</div>
-							<p class="card-description">{project.data.description}</p>
-							{project.data.stack.length > 0 && (
-								<div class="tags">
-									{project.data.stack.map((tech) => (
-										<span class="tag">{tech}</span>
-									))}
-								</div>
-							)}
-							{project.data.links && (
-								<div class="card-links">
-									{project.data.links.github && (
-										<a href={project.data.links.github}>GitHub</a>
-									)}
-									{project.data.links.live && (
-										<a href={project.data.links.live}>Live</a>
-									)}
-									{project.data.links.demo && (
-										<a href={project.data.links.demo}>Demo</a>
-									)}
-								</div>
-							)}
-						</article>
+					{featuredProjects.map((project) => (
+						<ProjectCard
+							title={project.data.title}
+							description={project.data.description}
+							status={project.data.status}
+							version={project.data.version}
+							stack={project.data.stack}
+							slug={project.slug}
+							links={project.data.links}
+						/>
 					))}
 				</div>
-				<a href="/projects" class="btn btn--secondary">View all projects</a>
 			</section>
 		)}
 
 		{recentPosts.length > 0 && (
 			<section class="section">
-				<h2 class="section-label">Recent Posts</h2>
+				<div class="section-header">
+					<h2 class="section-label">Recent Posts</h2>
+					<a href="/blog" class="section-link">View all &rarr;</a>
+				</div>
 				<div class="card-list">
 					{recentPosts.map((post) => (
-						<article class="card">
-							<div class="card-header">
-								<h3><a href={`/blog/${post.slug}`}>{post.data.title}</a></h3>
-								<time class="text-muted" datetime={post.data.publishedAt.toISOString()}>
-									{formatDate(post.data.publishedAt)}
-								</time>
-							</div>
-							<p class="card-description">{post.data.description}</p>
-							{post.data.tags.length > 0 && (
-								<div class="tags">
-									{post.data.tags.map((tag) => (
-										<span class="tag">{tag}</span>
-									))}
-								</div>
-							)}
-						</article>
+						<PostCard
+							title={post.data.title}
+							description={post.data.description}
+							publishedAt={post.data.publishedAt}
+							tags={post.data.tags}
+							slug={post.slug}
+						/>
 					))}
 				</div>
-				<a href="/blog" class="btn btn--secondary">View all posts</a>
 			</section>
 		)}
 	</div>
@@ -111,46 +89,31 @@ const recentPosts = allPosts.sort((a, b) => b.data.publishedAt.valueOf() - a.dat
 		margin-top: var(--space-3xl);
 	}
 
-	.section-label {
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
 		margin-bottom: var(--space-lg);
+	}
+
+	.section-link {
+		font-size: var(--font-size-sm);
+		color: var(--color-text-muted);
+	}
+
+	.section-link:hover {
+		color: var(--color-accent);
 	}
 
 	.card-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 		gap: var(--space-lg);
-		margin-bottom: var(--space-xl);
 	}
 
 	.card-list {
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-lg);
-		margin-bottom: var(--space-xl);
-	}
-
-	.card-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: baseline;
-		gap: var(--space-md);
-		margin-bottom: var(--space-sm);
-	}
-
-	.card-description {
-		color: var(--color-text-muted);
-		margin-bottom: var(--space-md);
-	}
-
-	.tags {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--space-xs);
-	}
-
-	.card-links {
-		display: flex;
-		gap: var(--space-md);
-		margin-top: var(--space-md);
 	}
 </style>

--- a/src/pages/learning/[...slug].astro
+++ b/src/pages/learning/[...slug].astro
@@ -1,0 +1,174 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { formatDate } from '../../utils/formatDate';
+
+export async function getStaticPaths() {
+  const logs = await getCollection('learning');
+  return logs.map((log) => ({
+    params: { slug: log.slug },
+    props: { log },
+  }));
+}
+
+const { log } = Astro.props;
+const { Content } = await log.render();
+
+const statusMap: Record<string, string> = {
+  'in-progress': 'idea',
+  'completed': 'active',
+  'paused': 'maintained',
+};
+---
+
+<BaseLayout title={log.data.title} description={log.data.description}>
+  <article class="learning-detail">
+    <header class="learning-header">
+      <a href="/learning" class="back-link">&larr; Back to learning</a>
+      <div class="title-row">
+        <h1>{log.data.title}</h1>
+        <span class={`status-badge status-badge--${statusMap[log.data.status]}`}>
+          {log.data.status}
+        </span>
+      </div>
+      <p class="learning-description">{log.data.description}</p>
+      <div class="learning-meta">
+        <time datetime={log.data.startedAt.toISOString()}>
+          Started: {formatDate(log.data.startedAt)}
+        </time>
+        {log.data.updatedAt && (
+          <time datetime={log.data.updatedAt.toISOString()}>
+            Updated: {formatDate(log.data.updatedAt)}
+          </time>
+        )}
+      </div>
+      {log.data.tags.length > 0 && (
+        <div class="learning-tags">
+          {log.data.tags.map((tag) => (
+            <a href={`/tags/${tag}`} class="tag">{tag}</a>
+          ))}
+        </div>
+      )}
+    </header>
+    <div class="learning-content">
+      <Content />
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .learning-detail {
+    max-width: 600px;
+  }
+
+  .back-link {
+    display: inline-block;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-lg);
+  }
+
+  .back-link:hover {
+    color: var(--color-accent);
+  }
+
+  .learning-header {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .title-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .learning-description {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+
+  .learning-meta {
+    display: flex;
+    gap: var(--space-lg);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+
+  .learning-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  .learning-content {
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-relaxed);
+    color: var(--color-text-muted);
+  }
+
+  .learning-content :global(p) {
+    margin-bottom: var(--space-lg);
+  }
+
+  .learning-content :global(h2) {
+    font-size: var(--font-size-xl);
+    color: var(--color-accent);
+    margin-top: var(--space-2xl);
+    margin-bottom: var(--space-md);
+    padding-bottom: var(--space-sm);
+    border-bottom: 2px solid var(--color-accent-muted);
+  }
+
+  .learning-content :global(h3) {
+    font-size: var(--font-size-lg);
+    color: var(--color-text);
+    margin-top: var(--space-xl);
+    margin-bottom: var(--space-sm);
+  }
+
+  .learning-content :global(ul),
+  .learning-content :global(ol) {
+    margin-bottom: var(--space-lg);
+    padding-left: var(--space-lg);
+  }
+
+  .learning-content :global(li) {
+    margin-bottom: var(--space-sm);
+  }
+
+  .learning-content :global(strong) {
+    color: var(--color-text);
+  }
+
+  .learning-content :global(a) {
+    color: var(--color-accent);
+  }
+
+  .learning-content :global(blockquote) {
+    border-left: 3px solid var(--color-accent);
+    padding-left: var(--space-md);
+    margin: var(--space-lg) 0;
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .learning-content :global(pre) {
+    margin-bottom: var(--space-lg);
+    border-radius: var(--radius-lg);
+    overflow-x: auto;
+  }
+
+  @media (max-width: 640px) {
+    .title-row {
+      flex-direction: column;
+      gap: var(--space-sm);
+    }
+
+    .learning-meta {
+      flex-direction: column;
+      gap: var(--space-xs);
+    }
+  }
+</style>

--- a/src/pages/learning/index.astro
+++ b/src/pages/learning/index.astro
@@ -1,0 +1,132 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { formatDate } from '../../utils/formatDate';
+
+const allLogs = await getCollection('learning');
+const logs = allLogs.sort((a, b) => {
+  const dateA = a.data.updatedAt ?? a.data.startedAt;
+  const dateB = b.data.updatedAt ?? b.data.startedAt;
+  return dateB.valueOf() - dateA.valueOf();
+});
+
+const statusMap: Record<string, string> = {
+  'in-progress': 'idea',
+  'completed': 'active',
+  'paused': 'maintained',
+};
+---
+
+<BaseLayout title="Learning" description="Structured notes on topics I'm actively studying.">
+  <div class="learning-index">
+    <header class="page-header">
+      <h1>Learning Log</h1>
+      <p class="text-muted">Structured notes on topics I'm actively studying.</p>
+    </header>
+
+    {logs.length > 0 ? (
+      <div class="log-list">
+        {logs.map((log) => (
+          <article class="log-item">
+            <div class="log-header">
+              <h3><a href={`/learning/${log.slug}`}>{log.data.title}</a></h3>
+              <span class={`status-badge status-badge--${statusMap[log.data.status]}`}>
+                {log.data.status}
+              </span>
+            </div>
+            <p class="log-description">{log.data.description}</p>
+            <div class="log-meta">
+              <time class="text-muted" datetime={(log.data.updatedAt ?? log.data.startedAt).toISOString()}>
+                Last updated: {formatDate(log.data.updatedAt ?? log.data.startedAt)}
+              </time>
+              {log.data.tags.length > 0 && (
+                <div class="tags">
+                  {log.data.tags.map((tag) => (
+                    <a href={`/tags/${tag}`} class="tag">{tag}</a>
+                  ))}
+                </div>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    ) : (
+      <p class="empty-state text-muted">No learning logs yet. Check back soon!</p>
+    )}
+  </div>
+</BaseLayout>
+
+<style>
+  .page-header {
+    margin-bottom: var(--space-xl);
+  }
+
+  .page-header h1 {
+    margin-bottom: var(--space-sm);
+  }
+
+  .log-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .log-item {
+    padding: var(--space-lg);
+    background: var(--color-bg-secondary);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border);
+    transition: border-color var(--transition-fast);
+  }
+
+  .log-item:hover {
+    border-color: var(--color-accent);
+  }
+
+  .log-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .log-header h3 a {
+    color: var(--color-text);
+    text-decoration: none;
+  }
+
+  .log-header h3 a:hover {
+    color: var(--color-accent);
+  }
+
+  .log-description {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+
+  .log-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  .empty-state {
+    padding: var(--space-2xl) 0;
+    text-align: center;
+  }
+
+  @media (max-width: 640px) {
+    .log-header {
+      flex-direction: column;
+      gap: var(--space-xs);
+    }
+  }
+</style>

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -1,0 +1,32 @@
+---
+import { getCollection } from 'astro:content';
+import ProjectLayout from '../../layouts/ProjectLayout.astro';
+import Changelog from '../../components/Changelog.astro';
+
+export async function getStaticPaths() {
+  const projects = await getCollection('projects', ({ data }) => !data.draft);
+  return projects.map((project) => ({
+    params: { slug: project.slug },
+    props: { project },
+  }));
+}
+
+const { project } = Astro.props;
+const { Content } = await project.render();
+
+// Extract changelog from frontmatter if present, otherwise empty
+const changelog = (project.data as any).changelog ?? [];
+---
+
+<ProjectLayout
+  title={project.data.title}
+  description={project.data.description}
+  status={project.data.status}
+  version={project.data.version}
+  tags={project.data.tags}
+  stack={project.data.stack}
+  links={project.data.links}
+>
+  <Content />
+  <Changelog entries={changelog} />
+</ProjectLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,65 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import ProjectCard from '../../components/ProjectCard.astro';
+
+const allProjects = await getCollection('projects', ({ data }) => !data.draft);
+
+const featuredProjects = allProjects
+  .filter((p) => p.data.featured)
+  .sort((a, b) => b.data.startedAt.valueOf() - a.data.startedAt.valueOf());
+
+const otherProjects = allProjects
+  .filter((p) => !p.data.featured)
+  .sort((a, b) => b.data.startedAt.valueOf() - a.data.startedAt.valueOf());
+
+const projects = [...featuredProjects, ...otherProjects];
+---
+
+<BaseLayout title="Projects" description="Things I'm building — apps, tools, and experiments.">
+  <div class="projects-index">
+    <header class="page-header">
+      <h1>Projects</h1>
+      <p class="text-muted">Things I'm building — apps, tools, and experiments.</p>
+    </header>
+
+    {projects.length > 0 ? (
+      <div class="project-grid">
+        {projects.map((project) => (
+          <ProjectCard
+            title={project.data.title}
+            description={project.data.description}
+            status={project.data.status}
+            version={project.data.version}
+            stack={project.data.stack}
+            slug={project.slug}
+            links={project.data.links}
+          />
+        ))}
+      </div>
+    ) : (
+      <p class="empty-state text-muted">No projects yet. Check back soon!</p>
+    )}
+  </div>
+</BaseLayout>
+
+<style>
+  .page-header {
+    margin-bottom: var(--space-xl);
+  }
+
+  .page-header h1 {
+    margin-bottom: var(--space-sm);
+  }
+
+  .project-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: var(--space-lg);
+  }
+
+  .empty-state {
+    padding: var(--space-2xl) 0;
+    text-align: center;
+  }
+</style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,183 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { formatDate } from '../../utils/formatDate';
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection('blog', ({ data }) => !data.draft);
+  const allProjects = await getCollection('projects', ({ data }) => !data.draft);
+  const allLearning = await getCollection('learning');
+
+  const tags = new Set<string>();
+  allPosts.forEach((p) => p.data.tags.forEach((t) => tags.add(t)));
+  allProjects.forEach((p) => p.data.tags.forEach((t) => tags.add(t)));
+  allLearning.forEach((l) => l.data.tags.forEach((t) => tags.add(t)));
+
+  return [...tags].map((tag) => ({
+    params: { tag },
+    props: {
+      tag,
+      posts: allPosts.filter((p) => p.data.tags.includes(tag))
+        .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf()),
+      projects: allProjects.filter((p) => p.data.tags.includes(tag))
+        .sort((a, b) => b.data.startedAt.valueOf() - a.data.startedAt.valueOf()),
+      learning: allLearning.filter((l) => l.data.tags.includes(tag))
+        .sort((a, b) => (b.data.updatedAt ?? b.data.startedAt).valueOf() - (a.data.updatedAt ?? a.data.startedAt).valueOf()),
+    },
+  }));
+}
+
+const { tag, posts, projects, learning } = Astro.props;
+
+const statusMap: Record<string, string> = {
+  'in-progress': 'idea',
+  'completed': 'active',
+  'paused': 'maintained',
+};
+---
+
+<BaseLayout title={`Tag: ${tag}`} description={`All content tagged with "${tag}".`}>
+  <div class="tag-page">
+    <header class="page-header">
+      <a href="/tags" class="back-link">&larr; All tags</a>
+      <h1>#{tag}</h1>
+      <p class="text-muted">
+        {posts.length + projects.length + learning.length} item{posts.length + projects.length + learning.length !== 1 ? 's' : ''}
+      </p>
+    </header>
+
+    {posts.length > 0 && (
+      <section class="content-section">
+        <h2 class="section-label">Blog Posts</h2>
+        <div class="item-list">
+          {posts.map((post) => (
+            <article class="list-item">
+              <div class="item-header">
+                <h3><a href={`/blog/${post.slug}`}>{post.data.title}</a></h3>
+                <time class="text-muted" datetime={post.data.publishedAt.toISOString()}>
+                  {formatDate(post.data.publishedAt)}
+                </time>
+              </div>
+              <p class="item-description">{post.data.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+
+    {projects.length > 0 && (
+      <section class="content-section">
+        <h2 class="section-label">Projects</h2>
+        <div class="item-list">
+          {projects.map((project) => (
+            <article class="list-item">
+              <div class="item-header">
+                <h3><a href={`/projects/${project.slug}`}>{project.data.title}</a></h3>
+                <span class={`status-badge status-badge--${project.data.status}`}>
+                  {project.data.status}
+                </span>
+              </div>
+              <p class="item-description">{project.data.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+
+    {learning.length > 0 && (
+      <section class="content-section">
+        <h2 class="section-label">Learning Logs</h2>
+        <div class="item-list">
+          {learning.map((log) => (
+            <article class="list-item">
+              <div class="item-header">
+                <h3><a href={`/learning/${log.slug}`}>{log.data.title}</a></h3>
+                <span class={`status-badge status-badge--${statusMap[log.data.status]}`}>
+                  {log.data.status}
+                </span>
+              </div>
+              <p class="item-description">{log.data.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+  </div>
+</BaseLayout>
+
+<style>
+  .page-header {
+    margin-bottom: var(--space-xl);
+  }
+
+  .back-link {
+    display: inline-block;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-lg);
+  }
+
+  .back-link:hover {
+    color: var(--color-accent);
+  }
+
+  .page-header h1 {
+    margin-bottom: var(--space-xs);
+    color: var(--color-accent);
+  }
+
+  .content-section {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .content-section .section-label {
+    margin-bottom: var(--space-md);
+  }
+
+  .item-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .list-item {
+    padding: var(--space-md) var(--space-lg);
+    background: var(--color-bg-secondary);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border);
+    transition: border-color var(--transition-fast);
+  }
+
+  .list-item:hover {
+    border-color: var(--color-accent);
+  }
+
+  .item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--space-md);
+    margin-bottom: var(--space-xs);
+  }
+
+  .item-header h3 a {
+    color: var(--color-text);
+    text-decoration: none;
+  }
+
+  .item-header h3 a:hover {
+    color: var(--color-accent);
+  }
+
+  .item-description {
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+
+  @media (max-width: 640px) {
+    .item-header {
+      flex-direction: column;
+      gap: var(--space-xs);
+    }
+  }
+</style>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,107 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const allPosts = await getCollection('blog', ({ data }) => !data.draft);
+const allProjects = await getCollection('projects', ({ data }) => !data.draft);
+const allLearning = await getCollection('learning');
+
+const tagCounts = new Map<string, number>();
+
+for (const post of allPosts) {
+  for (const tag of post.data.tags) {
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  }
+}
+
+for (const project of allProjects) {
+  for (const tag of project.data.tags) {
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  }
+}
+
+for (const log of allLearning) {
+  for (const tag of log.data.tags) {
+    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+  }
+}
+
+const sortedTags = [...tagCounts.entries()].sort((a, b) =>
+  a[0].localeCompare(b[0])
+);
+---
+
+<BaseLayout title="Tags" description="Browse all content by tag.">
+  <div class="tags-index">
+    <header class="page-header">
+      <h1>Tags</h1>
+      <p class="text-muted">Browse all content by tag.</p>
+    </header>
+
+    {sortedTags.length > 0 ? (
+      <div class="tag-cloud">
+        {sortedTags.map(([tag, count]) => (
+          <a href={`/tags/${tag}`} class="tag-item">
+            <span class="tag-name">{tag}</span>
+            <span class="tag-count">{count}</span>
+          </a>
+        ))}
+      </div>
+    ) : (
+      <p class="empty-state text-muted">No tags yet.</p>
+    )}
+  </div>
+</BaseLayout>
+
+<style>
+  .page-header {
+    margin-bottom: var(--space-xl);
+  }
+
+  .page-header h1 {
+    margin-bottom: var(--space-sm);
+  }
+
+  .tag-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+  }
+
+  .tag-item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: var(--color-text);
+    text-decoration: none;
+    transition: all var(--transition-fast);
+  }
+
+  .tag-item:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .tag-name {
+    font-size: var(--font-size-base);
+  }
+
+  .tag-count {
+    font-size: var(--font-size-sm);
+    font-family: var(--font-mono);
+    background: var(--color-bg-tertiary);
+    padding: 0 var(--space-xs);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+  }
+
+  .empty-state {
+    padding: var(--space-2xl) 0;
+    text-align: center;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -185,7 +185,7 @@ code {
    ================================ */
 
 .section-label {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   letter-spacing: var(--letter-spacing-wide);
   text-transform: uppercase;
@@ -207,19 +207,12 @@ code {
   white-space: nowrap;
   border: 0;
 }
-code {
-  font-family: var(--font-mono);
-  font-size: 0.9em;
-  background: var(--color-bg-secondary);
-  padding: 0.2em 0.4em;
-  border-radius: var(--radius-sm);
-}
 
 pre {
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
+  font-size: var(--font-size-sm);
   background: var(--color-bg-secondary);
-  padding: var(--space-4);
+  padding: var(--space-md);
   border-radius: var(--radius-lg);
   overflow-x: auto;
   border: 1px solid var(--color-border);
@@ -246,22 +239,14 @@ pre code {
   border: 0;
 }
 
-.section-label {
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-
 /* ===========================================
    COMPONENTS
    =========================================== */
 
 /* Tag */
 .tag {
-  font-size: var(--text-xs);
-  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  padding: var(--space-xs) var(--space-sm);
   border-radius: var(--radius-sm);
   background: var(--color-bg-tertiary);
   color: var(--color-text-muted);
@@ -274,7 +259,7 @@ pre code {
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  padding: var(--space-1) 10px;
+  padding: var(--space-xs) 10px;
   border-radius: var(--radius-sm);
 }
 
@@ -295,11 +280,11 @@ pre code {
 
 /* Card */
 .card {
-  padding: var(--space-6);
+  padding: var(--space-lg);
   background: var(--color-bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
-  transition: border-color var(--transition-normal);
+  transition: border-color var(--transition-base);
 }
 
 .card:hover {
@@ -310,10 +295,10 @@ pre code {
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-sm);
   padding: 10px 20px;
   font-family: inherit;
-  font-size: var(--text-sm);
+  font-size: var(--font-size-sm);
   font-weight: 500;
   border-radius: var(--radius-md);
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Add blog, projects, learning, and tags list/detail pages
- Extract `PostCard` and `ProjectCard` reusable components
- Refactor homepage to use shared card components with section header links
- Fix undefined CSS custom property references (`--text-*` → `--font-size-*`, `--space-N` → `--space-*`)
- Remove duplicate `.section-label` and `code` rule blocks in global styles
- Replace Astro starter README with project-specific documentation and content authoring guide
- Add example content templates in `docs/`

## Test plan
- [ ] `npm run build` passes
- [ ] Blog, projects, learning list pages render
- [ ] Detail pages render for each content type
- [ ] Tags index and individual tag pages render
- [ ] Homepage featured projects and recent posts use card components
- [ ] Light and dark themes work across all pages