### PR TITLE
feat: add learning section to homepage and improve content readability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# odeloic.com
+
+Personal site built with [Astro](https://astro.build).
+
+## Development
+
+```bash
+npm run dev      # start dev server
+npm run build    # production build
+npm run preview  # preview the build
+```
+
+## Content
+
+Content lives in `src/content/` across three collections:
+
+| Collection | Directory | Description |
+|---|---|---|
+| `blog` | `src/content/blog/` | Blog posts |
+| `projects` | `src/content/projects/` | Projects |
+| `learning` | `src/content/learning/` | Learning log |
+
+Schemas are defined in `src/content/config.ts`.
+
+### Scaffolding new entries
+
+```bash
+npm run new -- blog       # creates src/content/blog/YYYY-MM-DD.md
+npm run new -- project    # creates src/content/projects/YYYY-MM-DD.md
+npm run new -- learning   # creates src/content/learning/YYYY-MM-DD.md
+```
+
+The script (`scripts/new-content.js`) writes a pre-populated frontmatter stub named after today's date. It errors if the file already exists.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "new": "node scripts/new-content.js"
   },
   "dependencies": {
     "astro": "^5.16.15"

--- a/scripts/new-content.js
+++ b/scripts/new-content.js
@@ -1,0 +1,82 @@
+// Usage: npm run new -- <type>
+// Creates a pre-populated content stub for today's date.
+// type: blog | project | learning
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const COLLECTIONS = {
+  blog: "src/content/blog",
+  project: "src/content/projects",
+  learning: "src/content/learning",
+};
+
+const today = () => new Date().toLocaleDateString("en-CA"); // YYYY-MM-DD, local time
+
+const TEMPLATES = {
+  blog: (date) => `\
+---
+title: ""
+description: ""
+publishedAt: ${date}
+tags: []
+draft: true
+featured: false
+---
+`,
+  project: (date) => `\
+---
+title: ""
+description: ""
+status: "idea"
+startedAt: ${date}
+version: "0.1.0"
+tags: []
+stack: []
+featured: false
+draft: true
+---
+`,
+  learning: (date) => `\
+---
+title: ""
+description: ""
+startedAt: ${date}
+status: "in-progress"
+tags: []
+---
+
+## ${date}
+
+`,
+};
+
+const type = process.argv[2];
+
+if (!type || !COLLECTIONS[type]) {
+  console.error(
+    `Usage: npm run new -- <type>\nValid types: ${Object.keys(COLLECTIONS).join(", ")}`
+  );
+  process.exit(1);
+}
+
+const date = today();
+const dir = resolve(ROOT, COLLECTIONS[type]);
+const filePath = resolve(dir, `${date}.md`);
+
+await mkdir(dir, { recursive: true });
+
+try {
+  await writeFile(filePath, TEMPLATES[type](date), { flag: "wx" });
+} catch (err) {
+  if (err.code === "EEXIST") {
+    console.error(`File already exists: ${filePath}`);
+    process.exit(1);
+  }
+  throw err;
+}
+
+console.log(filePath);

--- a/src/content/learning/2026-02-22.md
+++ b/src/content/learning/2026-02-22.md
@@ -1,0 +1,20 @@
+---
+title: "System Design & AI agents"
+description: "So far... about system design and AI agents"
+startedAt: 2026-02-22
+status: "in-progress"
+tags: []
+---
+
+
+## System Design
+As i find myself using AI more and more for writing my coding, i thought it would be good to at least compensate that with learning more about system design. How do you go from a simple client/server application to a distributed systems, where you have many components in play. System design always comes up when you think about interviewing, but i think this is a very important skill to have now. If writing code becomes a trivial task, or at least a non time consuming task (because there is a craft/skill in writing good code), designing a good system will be primal.
+
+### How i have been ‘vibe coding’ so far?
+After defining a clear scope of what it is that I am trying to do, I always go back and forth with the AI by asking things I am not sure about like ‘what can be a good DB for this kind of system’, and ‘WHY not X?’, ‘What happens if at some point i need to change to Y?’, ‘Can X be easily deployed on…’. These are things that I am not familiar with, and by asking and reading the answers, and references provided with the answers, i get to learn in the process.
+
+So where I am getting at, is that knowing how systems work, and what components are needed to build a good system will help me in the future (the future, where agentic coding is mainstream), to at least have good foundations/architecture in place. There are a lot of resources about System Design online, a lot of youtube videos on System Design interviews, but since I like long form / workshop-style courses, I am taking the [Backend System Design course](https://frontendmasters.com/courses/backend-system-design/) on Frontend Masters taught by [Jem Young](https://www.linkedin.com/in/jemyoung/). So far, in the chapters i went through, I have learned what kind of questions you should ask before designing a system, identifying requirements, functional and non functional. Although, these are topics I learned about at school, but it wasn’t in a context of everyday work. I am looking forward, to the next chapters about High level design and Scaling.
+
+
+## Building AI agents
+I’ve been hearing a lot about AI agents for the past 2 years. And to be honest, only a few weeks ago i got curious enough to actually take a course on how to build one. And to my surprise, it wasn’t what i expected? I expected some very complex architecture, deep understanding on machine learning, and maths (which terrifies me 😀 as a ‘software engineer’) only to find out its just literally calling LLM APIs. Or at least, at the high level. However, taking [AI Agents Fundaments v2](https://frontendmasters.com/courses/ai-agents-v2/) by [Scott Moss](https://www.linkedin.com/in/williams-s-m/) on Frontend Masters, taught me a few terminologies about AI that i didn’t understand: like tools, evals, etc… At least now I know what an AI agent is, and I hope by the end of this course I should try and build a few personal agents that do something or nothing. I will share a more in depth article once i finish this course, and hopefully have a working demo to share what I have learned. stay tuned ;)

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -44,7 +44,7 @@ const { title, description, publishedAt, updatedAt, tags } = Astro.props;
 
 <style>
   .post {
-    max-width: 600px;
+    max-width: 100%;
   }
 
   .back-link {
@@ -85,7 +85,7 @@ const { title, description, publishedAt, updatedAt, tags } = Astro.props;
   .post-content {
     font-size: var(--font-size-base);
     line-height: var(--line-height-relaxed);
-    color: var(--color-text-muted);
+    color: var(--color-text);
   }
 
   .post-content :global(p) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import PostCard from "../components/PostCard.astro";
 import ProjectCard from "../components/ProjectCard.astro";
+import { formatDate } from "../utils/formatDate";
 
 const allProjects = await getCollection('projects');
 const featuredProjects = allProjects
@@ -13,6 +14,21 @@ const allPosts = await getCollection('blog', ({ data: blog }) => !blog.draft);
 const recentPosts = allPosts
 	.sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf())
 	.slice(0, 3);
+
+const allLearning = await getCollection('learning');
+const recentLearning = allLearning
+	.sort((a, b) => {
+		const dateA = a.data.updatedAt ?? a.data.startedAt;
+		const dateB = b.data.updatedAt ?? b.data.startedAt;
+		return dateB.valueOf() - dateA.valueOf();
+	})
+	.slice(0, 3);
+
+const statusMap: Record<string, string> = {
+	'in-progress': 'idea',
+	'completed': 'active',
+	'paused': 'maintained',
+};
 ---
 
 <BaseLayout title="Home" description="Fullstack software engineer. Building apps with React Native and Expo.">
@@ -67,6 +83,40 @@ const recentPosts = allPosts
 				</div>
 			</section>
 		)}
+
+		{recentLearning.length > 0 && (
+			<section class="section">
+				<div class="section-header">
+					<h2 class="section-label">Learning</h2>
+					<a href="/learning" class="section-link">View all &rarr;</a>
+				</div>
+				<div class="card-list">
+					{recentLearning.map((log) => (
+						<article class="log-item">
+							<div class="log-header">
+								<h3><a href={`/learning/${log.slug}`}>{log.data.title}</a></h3>
+								<span class={`status-badge status-badge--${statusMap[log.data.status]}`}>
+									{log.data.status}
+								</span>
+							</div>
+							<p class="log-description">{log.data.description}</p>
+							<div class="log-meta">
+								<time class="text-muted" datetime={(log.data.updatedAt ?? log.data.startedAt).toISOString()}>
+									{formatDate(log.data.updatedAt ?? log.data.startedAt)}
+								</time>
+								{log.data.tags.length > 0 && (
+									<div class="tags">
+										{log.data.tags.map((tag) => (
+											<a href={`/tags/${tag}`} class="tag">{tag}</a>
+										))}
+									</div>
+								)}
+							</div>
+						</article>
+					))}
+				</div>
+			</section>
+		)}
 	</div>
 </BaseLayout>
 
@@ -115,5 +165,53 @@ const recentPosts = allPosts
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-lg);
+	}
+
+	.log-item {
+		padding: var(--space-lg);
+		background: var(--color-bg-secondary);
+		border-radius: var(--radius-lg);
+		border: 1px solid var(--color-border);
+		transition: border-color var(--transition-fast);
+	}
+
+	.log-item:hover {
+		border-color: var(--color-accent);
+	}
+
+	.log-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: var(--space-md);
+		margin-bottom: var(--space-sm);
+	}
+
+	.log-header h3 a {
+		color: var(--color-text);
+		text-decoration: none;
+	}
+
+	.log-header h3 a:hover {
+		color: var(--color-accent);
+	}
+
+	.log-description {
+		color: var(--color-text-muted);
+		margin-bottom: var(--space-md);
+	}
+
+	.log-meta {
+		display: flex;
+		align-items: center;
+		gap: var(--space-md);
+		flex-wrap: wrap;
+	}
+
+	@media (max-width: 640px) {
+		.log-header {
+			flex-direction: column;
+			gap: var(--space-xs);
+		}
 	}
 </style>

--- a/src/pages/learning/[...slug].astro
+++ b/src/pages/learning/[...slug].astro
@@ -25,12 +25,7 @@ const statusMap: Record<string, string> = {
   <article class="learning-detail">
     <header class="learning-header">
       <a href="/learning" class="back-link">&larr; Back to learning</a>
-      <div class="title-row">
-        <h1>{log.data.title}</h1>
-        <span class={`status-badge status-badge--${statusMap[log.data.status]}`}>
-          {log.data.status}
-        </span>
-      </div>
+      <h1>{log.data.title}</h1>
       <p class="learning-description">{log.data.description}</p>
       <div class="learning-meta">
         <time datetime={log.data.startedAt.toISOString()}>
@@ -42,6 +37,9 @@ const statusMap: Record<string, string> = {
           </time>
         )}
       </div>
+      <span class={`status-badge status-badge--${statusMap[log.data.status]}`}>
+        {log.data.status}
+      </span>
       {log.data.tags.length > 0 && (
         <div class="learning-tags">
           {log.data.tags.map((tag) => (
@@ -58,7 +56,7 @@ const statusMap: Record<string, string> = {
 
 <style>
   .learning-detail {
-    max-width: 600px;
+    max-width: 100%;
   }
 
   .back-link {
@@ -76,10 +74,7 @@ const statusMap: Record<string, string> = {
     margin-bottom: var(--space-2xl);
   }
 
-  .title-row {
-    display: flex;
-    align-items: baseline;
-    gap: var(--space-md);
+  .learning-header h1 {
     margin-bottom: var(--space-sm);
   }
 
@@ -93,7 +88,7 @@ const statusMap: Record<string, string> = {
     gap: var(--space-lg);
     font-size: var(--font-size-sm);
     color: var(--color-text-muted);
-    margin-bottom: var(--space-md);
+    margin-bottom: var(--space-sm);
   }
 
   .learning-tags {
@@ -105,7 +100,7 @@ const statusMap: Record<string, string> = {
   .learning-content {
     font-size: var(--font-size-base);
     line-height: var(--line-height-relaxed);
-    color: var(--color-text-muted);
+    color: var(--color-text);
   }
 
   .learning-content :global(p) {
@@ -161,11 +156,6 @@ const statusMap: Record<string, string> = {
   }
 
   @media (max-width: 640px) {
-    .title-row {
-      flex-direction: column;
-      gap: var(--space-sm);
-    }
-
     .learning-meta {
       flex-direction: column;
       gap: var(--space-xs);


### PR DESCRIPTION
## Summary
- Add learning log section to the homepage showing up to 3 recent entries
- Widen content area on learning detail and blog post layouts (remove 600px cap)
- Move status badge below date on learning detail page
- Fix body text contrast: use `--color-text` instead of `--color-text-muted` for article content

## Test plan
- [ ] Verify learning section appears on homepage with correct cards
- [ ] Check learning detail page layout and status badge placement
- [ ] Confirm body text readability in both light and dark themes
- [ ] Verify blog post layout is also wider and readable